### PR TITLE
Update SDK info and support library to v22

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         applicationId "com.javacodegeeks.androidcameraexample"
         minSdkVersion 17
-        targetSdkVersion 19
+        targetSdkVersion 22
     }
 
     buildTypes {
@@ -22,7 +22,7 @@ repositories{mavenCentral()}
 
 dependencies {
     compile 'com.facebook.android:facebook-android-sdk:4.0.1'
-    compile 'com.android.support:support-v4:19.1.0'
+    compile 'com.android.support:support-v4:22.1.0'
     compile 'com.parse.bolts:bolts-android:1.+'
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile files('libs/Parse-1.9.1.jar')


### PR DESCRIPTION
v22 is the latest SDK version (just got a big update yesterday) that deprecated a lot of older methods. Might as well migrate now to avoid using deprecated stuff.

You should also change the package name from 'com.javacodegeeks.cameraexample' to 'com.yourdomain.snaproulette' sooner rather than later. It will become more of a pain to refactor later on. I think Android Studio can do the refactor for you.
